### PR TITLE
Move individual config items to top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
 Ansible Role that installs and configure s3fs on Debian/Ubuntu. Aditionally, install a start/stop script to mount/unmount buckets and add the mountpoints to the fstab file.
 
 
-## Requirements
-
-Use hash behavior for variables in ansible.cfg
-See example: https://github.com/Aplyca/ansible-role-s3fs/blob/master/tests/ansible.cfg
-See official docs: http://docs.ansible.com/intro_configuration.html#hash-behaviour
-
 ## Installation
 
 Using ansible galaxy:
@@ -24,20 +18,17 @@ dependencies:
   - { role: Aplyca.S3fs }
 ```
 
-Use `merge` hash behaviour for variables like dictionaries in Python. You can set this configuration by adding the setting `hash_behaviour=merge` to the `ansible.cfg` file which should be placed in the same directory where you are executing ansible-playbook command. See the docs for more info: http://docs.ansible.com/ansible/intro_configuration.html#hash-behaviour or see the example here: https://github.com/Aplyca/ansible-role-s3fs/blob/master/ansible.cfg
-
 ## Role Variables
 
 See default variables: https://github.com/Aplyca/ansible-role-s3fs/blob/master/defaults/main.yml
 
 ```yaml
-s3fs:
-  buckets:
-    - mountpoint: /mnt/s3fs
-      bucket: s3fs
-      accessKeyId: "accessKeyId"
-      secretAccessKey: "secretAccessKey"
-      options: "allow_other,use_cache=/tmp,max_stat_cache_size=100000,uid=33,gid=33,umask=002"
+s3fs_buckets:
+  - mountpoint: /mnt/s3fs
+    bucket: s3fs
+    accessKeyId: "accessKeyId"
+    secretAccessKey: "secretAccessKey"
+    options: "allow_other,use_cache=/tmp,max_stat_cache_size=100000,uid=33,gid=33,umask=002"
 ```
 
 ## Dependencies

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,6 @@
 roles_path=../
 hostfile=inventory
 hosts=localhost
-hash_behaviour=merge
 host_key_checking = False
 force_color = True
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-s3fs:
-  source: "https://github.com/s3fs-fuse/s3fs-fuse/archive/v1.78.tar.gz"
-  buckets: []
-  add_to_fstab: True
+s3fs_source: "https://github.com/s3fs-fuse/s3fs-fuse/archive/v1.78.tar.gz"
+s3fs_buckets: []
+s3fs_add_to_fstab: True

--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -4,7 +4,7 @@
   file:
     path: "{{ item.mountpoint }}"
     state: directory
-  with_items: "{{ s3fs.buckets }}"
+  with_items: "{{ s3fs_buckets }}"
   ignore_errors: yes
   no_log: True
 
@@ -12,10 +12,10 @@
   become: yes
   template:
     src: passwd-s3fs.j2
-    dest: "{{ s3fs.passwd_file }}"
+    dest: "{{ s3fs_passwd_file }}"
     mode: 0640
     owner: "{{ ansible_user_id }}"
-  with_items: "{{ s3fs.buckets }}"
+  with_items: "{{ s3fs_buckets }}"
   notify: restart s3fs
   no_log: True
 
@@ -38,8 +38,8 @@
     name: "{{ item.mountpoint }}"
     src: "s3fs#{{ item.bucket }}"
     fstype: fuse
-    opts: "_netdev,{{ item.options }},passwd_file={{ s3fs.passwd_file }}"
+    opts: "_netdev,{{ item.options }},passwd_file={{ s3fs_passwd_file }}"
     state: present
-  with_items: "{{ s3fs.buckets }}"
-  when: s3fs.buckets is defined and s3fs.add_to_fstab
+  with_items: "{{ s3fs_buckets }}"
+  when: s3fs_buckets is defined and s3fs_add_to_fstab
   no_log: True

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -6,11 +6,11 @@
     state: present
     update_cache: yes
     cache_valid_time: 86400
-  with_items: "{{ s3fs.dependencies }}"
+  with_items: "{{ s3fs_dependencies }}"
 
 - name: Download s3fs source
   get_url:
-    url: "{{ s3fs.source }}"
+    url: "{{ s3fs_source }}"
     dest: "~/s3fs-fuse.package"
 
 - name: Uncompress s3fs

--- a/templates/passwd-s3fs.j2
+++ b/templates/passwd-s3fs.j2
@@ -1,3 +1,3 @@
-{% for bucket in s3fs.buckets %}
+{% for bucket in s3fs_buckets %}
 {{ bucket.bucket }}:{{ bucket.accessKeyId | default('accessKeyId') }}:{{ bucket.secretAccessKey | default('secretAccessKey') }}
 {% endfor %}

--- a/templates/s3fs.j2
+++ b/templates/s3fs.j2
@@ -20,9 +20,9 @@ SCRIPTNAME=/etc/init.d/$NAME
 #
 do_start()
 {
-    {% if s3fs.buckets is defined %}
-      {% for bucket in s3fs.buckets %}
-        mountpoint {{ bucket.mountpoint }} | grep -q 'is a mountpoint' && (echo '{{ bucket.bucket }} already mounted') || ({{ s3fs.daemon }} {{ bucket.bucket }} {{ bucket.mountpoint }} -o{{ bucket.options }},passwd_file={{ s3fs.passwd_file }} && echo '{{ bucket.bucket }} mounted')
+    {% if s3fs_buckets is defined %}
+      {% for bucket in s3fs_buckets %}
+        mountpoint {{ bucket.mountpoint }} | grep -q 'is a mountpoint' && (echo '{{ bucket.bucket }} already mounted') || ({{ s3fs_daemon }} {{ bucket.bucket }} {{ bucket.mountpoint }} -o{{ bucket.options }},passwd_file={{ s3fs_passwd_file }} && echo '{{ bucket.bucket }} mounted')
       {% else %}
         echo 'No buckets to mount'
       {% endfor %}
@@ -34,8 +34,8 @@ do_start()
 #
 do_stop()
 {
-    {% if s3fs.buckets is defined %}
-      {% for bucket in s3fs.buckets %}
+    {% if s3fs_buckets is defined %}
+      {% for bucket in s3fs_buckets %}
         mountpoint {{ bucket.mountpoint }} | grep -q 'is a mountpoint' && (umount {{ bucket.mountpoint }} && echo '{{ bucket.bucket }} unmounted') || (echo '{{ bucket.bucket }} not mounted')
       {% else %}
         echo 'No buckets to unmount'
@@ -48,8 +48,8 @@ do_stop()
 #
 do_status()
 {
-    {% if s3fs.buckets is defined %}
-      {% for bucket in s3fs.buckets %}
+    {% if s3fs_buckets is defined %}
+      {% for bucket in s3fs_buckets %}
         mountpoint {{ bucket.mountpoint }} | grep -q 'is a mountpoint' && (echo '{{ bucket.bucket }} is mounted') || (echo '{{ bucket.bucket }} not mounted')
       {% else %}
         echo 'No buckets available'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,15 +1,14 @@
 ---
-s3fs:
-  passwd_file: /etc/passwd-s3fs
-  daemon: /usr/local/bin/s3fs
-  dependencies:
-    - unzip
-    - fuse
-    - build-essential
-    - libfuse-dev
-    - libcurl4-openssl-dev
-    - libxml2-dev
-    - mime-support
-    - automake
-    - libtool
-    - ntp
+s3fs_passwd_file: /etc/passwd-s3fs
+s3fs_daemon: /usr/local/bin/s3fs
+s3fs_dependencies:
+  - unzip
+  - fuse
+  - build-essential
+  - libfuse-dev
+  - libcurl4-openssl-dev
+  - libxml2-dev
+  - mime-support
+  - automake
+  - libtool
+  - ntp


### PR DESCRIPTION
This eliminates the need to set the hash behavior to "merge" which is
discouraged by the Ansible documentation. Ansible's usual precedence
rules are used instead.
#4
